### PR TITLE
Initial phase of optimizations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: git://github.com/dnephin/pre-commit-golang
+- repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.4.0
   hooks:
     - id: go-fmt

--- a/sqli.go
+++ b/sqli.go
@@ -14,8 +14,6 @@ type sqliState struct {
 	// length, input length
 	length int
 
-	lookup lookup
-
 	flags int
 
 	// position is the index in the string during tokenization
@@ -75,7 +73,6 @@ func sqliInit(s *sqliState, input string, flags int) {
 	*s = sqliState{}
 	s.input = input
 	s.length = len(input)
-	s.lookup = s.lookupWord
 	s.flags = flags
 	s.current = &s.tokenVec[0]
 }
@@ -83,11 +80,12 @@ func sqliInit(s *sqliState, input string, flags int) {
 // secondary api: detects SQLi in a string, GIVEN a context.
 //
 // A context can be:
-// 		ByteNull (\0), process as is
-// 		ByteSingle ('), process pretending input started with a
-// 		    single quote.
-//      ByteDouble ("), process pretending input started with a
-//          double quote.
+//
+//			ByteNull (\0), process as is
+//			ByteSingle ('), process pretending input started with a
+//			    single quote.
+//	     ByteDouble ("), process pretending input started with a
+//	         double quote.
 func (s *sqliState) sqliFingerprint(flags int) []byte {
 	s.reset(flags)
 	length := s.fold()
@@ -174,7 +172,7 @@ func (s *sqliState) merge(tokenA, tokenB *sqliToken) bool {
 	copy(tmp[tokenA.len+1:], tokenB.val[:tokenB.len])
 
 	length := tokenA.len + tokenB.len + 1
-	ch := s.lookup(sqliLookupWord, tmp[:length])
+	ch := s.lookupWord(sqliLookupWord, tmp[:length])
 	if ch != byteNull {
 		tokenA.assign(ch, tokenA.pos, length, string(tmp[:length]))
 		return true
@@ -844,13 +842,10 @@ func (s *sqliState) lookupWord(lookupType int, word []byte) byte {
 }
 
 func (s *sqliState) reset(flags int) {
-	lookup := s.lookup
-
 	if flags == 0 {
 		flags = sqliFlagQuoteNone | sqliFlagSQLAnsi
 	}
 	sqliInit(s, s.input, flags)
-	s.lookup = lookup
 }
 
 // Main API, detects SQLi in an input
@@ -866,11 +861,11 @@ func (s *sqliState) check() bool {
 
 	// test input "as-is"
 	s.sqliFingerprint(sqliFlagQuoteNone | sqliFlagSQLAnsi)
-	if s.lookup(sqliLookupFingerprint, s.fingerprint) != byteNull {
+	if s.lookupWord(sqliLookupFingerprint, s.fingerprint) != byteNull {
 		return true
 	} else if s.reparseAsMySQL() {
 		s.sqliFingerprint(sqliFlagQuoteNone | sqliFlagSQLMysql)
-		if s.lookup(sqliLookupFingerprint, s.fingerprint) != byteNull {
+		if s.lookupWord(sqliLookupFingerprint, s.fingerprint) != byteNull {
 			return true
 		}
 	}
@@ -880,11 +875,11 @@ func (s *sqliState) check() bool {
 	// example: if input if "1' = 1", then pretend it's "'1' = 1"
 	if strings.ContainsRune(s.input, rune(byteSingle)) {
 		s.sqliFingerprint(sqliFlagQuoteSingle | sqliFlagSQLAnsi)
-		if s.lookup(sqliLookupFingerprint, s.fingerprint) != byteNull {
+		if s.lookupWord(sqliLookupFingerprint, s.fingerprint) != byteNull {
 			return true
 		} else if s.reparseAsMySQL() {
 			s.sqliFingerprint(sqliFlagQuoteSingle | sqliFlagSQLMysql)
-			if s.lookup(sqliLookupFingerprint, s.fingerprint) != byteNull {
+			if s.lookupWord(sqliLookupFingerprint, s.fingerprint) != byteNull {
 				return true
 			}
 		}
@@ -893,7 +888,7 @@ func (s *sqliState) check() bool {
 	// same as above but with a double quote
 	if strings.ContainsRune(s.input, rune(byteDouble)) {
 		s.sqliFingerprint(sqliFlagQuoteDouble | sqliFlagSQLMysql)
-		if s.lookup(sqliLookupFingerprint, s.fingerprint) != byteNull {
+		if s.lookupWord(sqliLookupFingerprint, s.fingerprint) != byteNull {
 			return true
 		}
 	}

--- a/sqli.go
+++ b/sqli.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-type lookup func(lookupType int, word []byte) byte
-
 type sqliState struct {
 	// input, does not need to be null terminated, it is also not modified.
 	input string

--- a/sqli_data.go
+++ b/sqli_data.go
@@ -325,7 +325,7 @@ type sqlKeyword struct {
 
 const sqlKeywordsLen = 9352
 
-var sqlKeywords = [9352]sqlKeyword{
+var sqlKeywords = []sqlKeyword{
 	{"!!", 'o'},
 	{"!<", 'o'},
 	{"!=", 'o'},

--- a/sqli_helpers.go
+++ b/sqli_helpers.go
@@ -67,7 +67,7 @@ func strLenSpn(s string, length int, accept string) int {
 	return length
 }
 
-func strLenCSpn(s string, length int, accept [256]byte) int {
+func strLenCSpn(s string, length int, accept []byte) int {
 	for i := 0; i < length; i++ {
 		if accept[s[i]] == 1 {
 			return i

--- a/sqli_helpers.go
+++ b/sqli_helpers.go
@@ -121,10 +121,11 @@ func searchKeyword(key []byte, keywords [sqlKeywordsLen]sqlKeyword) byte {
 		right = sqlKeywordsLen - 1
 	)
 
+	upperKey := strings.ToUpper(string(key))
+
 	for left < right {
 		pos := (left + right) >> 1
 
-		upperKey := strings.ToUpper(string(key))
 		switch {
 		case upperKey == keywords[pos].k:
 			return keywords[pos].v

--- a/sqli_helpers.go
+++ b/sqli_helpers.go
@@ -16,8 +16,9 @@ func flag2Delimiter(flag int) byte {
 }
 
 // OK! "	\"	" one backslash = escaped!
-// 	   "   \\"	" two backslash = not escaped!
-//     "  \\\"	" three backslash = escaped!
+//
+//		   "   \\"	" two backslash = not escaped!
+//	    "  \\\"	" three backslash = escaped!
 func isBackslashEscaped(str string) bool {
 	if !strings.ContainsRune(str, '\\') {
 		return false
@@ -65,9 +66,9 @@ func strLenSpn(s string, length int, accept string) int {
 	return length
 }
 
-func strLenCSpn(s string, length int, accept string) int {
+func strLenCSpn(s string, length int, accept [256]byte) int {
 	for i := 0; i < length; i++ {
-		if strings.ContainsRune(accept, rune(s[i])) {
+		if accept[s[i]] == 1 {
 			return i
 		}
 	}
@@ -83,7 +84,9 @@ func strLenCSpn(s string, length int, accept string) int {
 // the form of /x![anything]x/ or /x!12345[anything]x/
 //
 // MySQL3 (maybe 4), allowed this:
-// 		/x!0selectx/ 1;
+//
+//	/x!0selectx/ 1;
+//
 // where 0 could be any number
 //
 // The last version of MySQL 3 was in 2003.

--- a/sqli_helpers.go
+++ b/sqli_helpers.go
@@ -1,6 +1,7 @@
 package libinjection
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -115,25 +116,15 @@ func isKeyword(key []byte) byte {
 	return searchKeyword(key, sqlKeywords)
 }
 
-func searchKeyword(key []byte, keywords [sqlKeywordsLen]sqlKeyword) byte {
-	var (
-		left  = 0
-		right = sqlKeywordsLen - 1
-	)
-
+func searchKeyword(key []byte, keywords []sqlKeyword) byte {
 	upperKey := strings.ToUpper(string(key))
 
-	for left < right {
-		pos := (left + right) >> 1
+	i := sort.Search(sqlKeywordsLen, func(i int) bool {
+		return keywords[i].k >= upperKey
+	})
 
-		switch {
-		case upperKey == keywords[pos].k:
-			return keywords[pos].v
-		case upperKey > keywords[pos].k:
-			left = pos + 1
-		default:
-			right = pos
-		}
+	if i < sqlKeywordsLen && keywords[i].k == upperKey {
+		return keywords[i].v
 	}
 
 	return byteNull

--- a/sqli_parse.go
+++ b/sqli_parse.go
@@ -486,9 +486,9 @@ func parseBWord(s *sqliState) int {
 	return s.pos + end + 1
 }
 
-func buildAcceptTable(acceptStr string) [256]byte {
+func buildAcceptTable(acceptStr string) []byte {
 	accept := []byte(acceptStr)
-	acceptTable := [256]byte{}
+	acceptTable := make([]byte, 256, 256)
 	for i := 0; i < 256; i++ {
 		if bytes.IndexByte(accept, byte(i)) != -1 {
 			acceptTable[i] = 1

--- a/sqli_parse.go
+++ b/sqli_parse.go
@@ -488,7 +488,7 @@ func parseBWord(s *sqliState) int {
 
 func buildAcceptTable(acceptStr string) []byte {
 	accept := []byte(acceptStr)
-	acceptTable := make([]byte, 256, 256)
+	acceptTable := make([]byte, 256)
 	for i := 0; i < 256; i++ {
 		if bytes.IndexByte(accept, byte(i)) != -1 {
 			acceptTable[i] = 1

--- a/sqli_parse.go
+++ b/sqli_parse.go
@@ -1,8 +1,12 @@
 package libinjection
 
 import (
+	"bytes"
 	"strings"
 )
+
+var wordAcceptTable = buildAcceptTable(" []{}<>:\\?=@!#~+-*/&|^%(),';\t\n\v\f\r\"\240\000")
+var varAcceptTable = buildAcceptTable(" <>:\\?=@!#~+-*/&|^%(),';\t\n\v\f\r'`\"")
 
 func parseEolComment(s *sqliState) int {
 	index := strings.IndexByte(s.input[s.pos:], '\n')
@@ -185,7 +189,7 @@ func parseOperator2(s *sqliState) int {
 		return s.pos + 3
 	}
 
-	ch := s.lookup(sqliLookupOperator, []byte(s.input[s.pos:s.pos+2]))
+	ch := s.lookupWord(sqliLookupOperator, []byte(s.input[s.pos:s.pos+2]))
 	if ch != byteNull {
 		s.current.assign(ch, s.pos, 2, s.input[s.pos:])
 		return s.pos + 2
@@ -207,7 +211,7 @@ func parseString(s *sqliState) int {
 }
 
 func parseWord(s *sqliState) int {
-	length := strLenCSpn(s.input[s.pos:], s.length-s.pos, " []{}<>:\\?=@!#~+-*/&|^%(),';\t\n\v\f\r\"\240\000")
+	length := strLenCSpn(s.input[s.pos:], s.length-s.pos, wordAcceptTable)
 	s.current.assign(sqliTokenTypeBareWord, s.pos, length, s.input[s.pos:])
 
 	// now we need to look inside what we good for "." and "`"
@@ -215,7 +219,7 @@ func parseWord(s *sqliState) int {
 	for i := 0; i < s.current.len; i++ {
 		delimiter := s.current.val[i]
 		if delimiter == '.' || delimiter == '`' {
-			ch := s.lookup(sqliLookupWord, s.current.val[:i])
+			ch := s.lookupWord(sqliLookupWord, s.current.val[:i])
 			if ch != sqliTokenTypeNone && ch != sqliTokenTypeBareWord {
 				*s.current = sqliToken{}
 				// we got something like "SELECT.1"
@@ -228,7 +232,7 @@ func parseWord(s *sqliState) int {
 
 	// do normal lookup with word including '.'
 	if length < tokenSize {
-		ch := s.lookup(sqliLookupWord, s.current.val[:length])
+		ch := s.lookupWord(sqliLookupWord, s.current.val[:length])
 		if ch == byteNull {
 			ch = sqliTokenTypeBareWord
 		}
@@ -267,7 +271,7 @@ func parseVar(s *sqliState) int {
 		}
 	}
 
-	length := strLenCSpn(s.input[pos:], s.length-pos, " <>:\\?=@!#~+-*/&|^%(),';\t\n\v\f\r'`\"")
+	length := strLenCSpn(s.input[pos:], s.length-pos, varAcceptTable)
 	if length == 0 {
 		s.current.assign(sqliTokenTypeVariable, pos, 0, s.input[pos:])
 		return pos
@@ -379,7 +383,7 @@ func parseTick(s *sqliState) int {
 	//
 	// check value of string to see if it's a keyword,
 	// function, operator, etc
-	ch := s.lookup(sqliLookupWord, s.current.val[:s.current.len])
+	ch := s.lookupWord(sqliLookupWord, s.current.val[:s.current.len])
 	if ch == sqliTokenTypeFunction {
 		// if it's a function, then covert token
 		s.current.category = sqliTokenTypeFunction
@@ -459,8 +463,9 @@ func parseBString(s *sqliState) int {
 }
 
 // used when first byte is E or e:
-//		N or n: mysql "National Character set"
-// 		E     : psql  "Escaped String"
+//
+//	N or n: mysql "National Character set"
+//	E     : psql  "Escaped String"
 func parseEString(s *sqliState) int {
 	if s.pos+2 >= s.length || s.input[s.pos+1] != byteSingle {
 		return parseWord(s)
@@ -479,4 +484,15 @@ func parseBWord(s *sqliState) int {
 	}
 	s.current.assign(sqliTokenTypeBareWord, s.pos, end+1, s.input[s.pos:])
 	return s.pos + end + 1
+}
+
+func buildAcceptTable(acceptStr string) [256]byte {
+	accept := []byte(acceptStr)
+	acceptTable := [256]byte{}
+	for i := 0; i < 256; i++ {
+		if bytes.IndexByte(accept, byte(i)) != -1 {
+			acceptTable[i] = 1
+		}
+	}
+	return acceptTable
 }

--- a/sqli_test.go
+++ b/sqli_test.go
@@ -164,13 +164,13 @@ func TestSQLiDriver(t *testing.T) {
 }
 
 func BenchmarkSQLiDriver(b *testing.B) {
-	b.StopTimer()
 	baseDir := "./tests/"
 	dir, err := os.ReadDir(baseDir)
 	if err != nil {
 		b.Fatal(err)
 	}
 
+	b.ResetTimer()
 	for _, fi := range dir {
 		p := filepath.Join(baseDir, fi.Name())
 		data := readTestData(p)


### PR DESCRIPTION
- Use slice instead of array for SQL keywords. Go will copy the array every time copying the function - an alternative to slice would be pointer to array, but that is effectively what a slice is while being more idiomatic Go. (HUGE WIN)
- Remove function pointer lookup for calling lookupWord since there is only one implementation anyways
- Switch to stdlib binary search (at the same time prevented uppercasing every single iteration of the search loop)
- Use lookup table for ascii bytes instead of iterating

Still many more easy wins to be found I think, but after finding the HUGE WIN, want to get this in as a start, 30x improvement. More importantly, now CPU profiles actually make sense for finding more problems :D

After
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/libinjection-go
BenchmarkSQLiDriver
BenchmarkSQLiDriver/sqli
BenchmarkSQLiDriver/sqli-10         	   24558	     49123 ns/op
BenchmarkSQLiDriver/folding
BenchmarkSQLiDriver/folding-10      	   10000	    103913 ns/op
BenchmarkSQLiDriver/tokens
BenchmarkSQLiDriver/tokens-10       	    6902	    170414 ns/op
PASS
```

Before
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/libinjection-go
BenchmarkSQLiDriver
BenchmarkSQLiDriver/sqli
BenchmarkSQLiDriver/sqli-10         	     620	   1882274 ns/op
BenchmarkSQLiDriver/folding
BenchmarkSQLiDriver/folding-10      	     484	   2464673 ns/op
BenchmarkSQLiDriver/tokens
BenchmarkSQLiDriver/tokens-10       	     368	   3258661 ns/op
```