### PR TITLE
Use string type for current token and fingerprint

### DIFF
--- a/sqli.go
+++ b/sqli.go
@@ -165,16 +165,10 @@ func (s *sqliState) merge(tokenA, tokenB *sqliToken) bool {
 		return false
 	}
 
-	// oddly annoying last.val + ' ' + current.val
-	var tmp [tokenSize]byte
-	copy(tmp[:], tokenA.val[:tokenA.len])
-	tmp[tokenA.len] = ' '
-	copy(tmp[tokenA.len+1:], tokenB.val[:tokenB.len])
-
-	length := tokenA.len + tokenB.len + 1
-	ch := s.lookupWord(sqliLookupWord, string(tmp[:length]))
+	tmp := tokenA.val[:tokenA.len] + " " + tokenB.val[:tokenB.len]
+	ch := s.lookupWord(sqliLookupWord, tmp)
 	if ch != byteNull {
-		tokenA.assign(ch, tokenA.pos, length, string(tmp[:length]))
+		tokenA.assign(ch, tokenA.pos, len(tmp), tmp)
 		return true
 	}
 	return false

--- a/sqli.go
+++ b/sqli.go
@@ -664,23 +664,25 @@ func (s *sqliState) tokenize() bool {
 //
 // return TRUE if SQLi, false otherwise
 func (s *sqliState) blacklist() bool {
-	var fp []byte
 
 	length := len(s.fingerprint)
 	if length < 1 {
 		return false
 	}
 
-	fp = append(fp, '0')
+	fp := strings.Builder{}
+	fp.Grow(length + 1)
+
+	fp.WriteByte('0')
 	for i := 0; i < length; i++ {
 		ch := s.fingerprint[i]
 		if ch >= 'a' && ch <= 'z' {
 			ch -= 0x20
 		}
-		fp = append(fp, ch)
+		fp.WriteByte(ch)
 	}
 
-	return isKeyword(fp) == sqliTokenTypeFingerprint
+	return isKeyword(fp.String()) == sqliTokenTypeFingerprint
 }
 
 // Given a positive match for a pattern (i.e. pattern is SQLi), this function

--- a/sqli_helpers.go
+++ b/sqli_helpers.go
@@ -111,8 +111,8 @@ func toUpperCmp(a, b string) bool {
 	return a == strings.ToUpper(b)
 }
 
-func isKeyword(key []byte) byte {
-	return searchKeyword(string(key), sqlKeywords)
+func isKeyword(key string) byte {
+	return searchKeyword(key, sqlKeywords)
 }
 
 func searchKeyword(key string, keywords map[string]byte) byte {

--- a/sqli_helpers.go
+++ b/sqli_helpers.go
@@ -112,11 +112,11 @@ func toUpperCmp(a, b string) bool {
 }
 
 func isKeyword(key []byte) byte {
-	return searchKeyword(key, sqlKeywords)
+	return searchKeyword(string(key), sqlKeywords)
 }
 
-func searchKeyword(key []byte, keywords map[string]byte) byte {
-	upperKey := strings.ToUpper(string(key))
+func searchKeyword(key string, keywords map[string]byte) byte {
+	upperKey := strings.ToUpper(key)
 
 	if val, ok := keywords[upperKey]; ok {
 		return val

--- a/sqli_parse.go
+++ b/sqli_parse.go
@@ -21,7 +21,7 @@ func parseEolComment(s *sqliState) int {
 
 func parseMoney(s *sqliState) int {
 	if s.pos+1 == s.length {
-		s.current.assignByte(sqliTokenTypeBareWord, s.pos, 1, '$')
+		s.current.assign(sqliTokenTypeBareWord, s.pos, 1, "$")
 		return s.length
 	}
 
@@ -48,14 +48,14 @@ func parseMoney(s *sqliState) int {
 		xlen := strLenSpn(s.input[s.pos+1:], s.length-s.pos-1, "abcdefghjiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 		if xlen == 0 {
 			// hmm, it's "$" _something_ .. just add $ and keep going
-			s.current.assignByte(sqliTokenTypeBareWord, s.pos, 1, '$')
+			s.current.assign(sqliTokenTypeBareWord, s.pos, 1, "$")
 			return s.pos + 1
 		}
 
 		// we have $foobar?????
 		if s.pos+xlen+1 == s.length || s.input[s.pos+xlen+1] != '$' {
 			// not $foobar$, or fell off edge
-			s.current.assignByte(sqliTokenTypeBareWord, s.pos, 1, '$')
+			s.current.assign(sqliTokenTypeBareWord, s.pos, 1, "$")
 			return s.pos + 1
 		}
 
@@ -81,7 +81,7 @@ func parseMoney(s *sqliState) int {
 }
 
 func parseOther(s *sqliState) int {
-	s.current.assignByte(sqliTokenTypeUnknown, s.pos, 1, s.input[s.pos])
+	s.current.assign(sqliTokenTypeUnknown, s.pos, 1, s.input[s.pos:])
 	return s.pos + 1
 }
 
@@ -90,12 +90,12 @@ func parseWhite(s *sqliState) int {
 }
 
 func parseOperator1(s *sqliState) int {
-	s.current.assignByte(sqliTokenTypeOperator, s.pos, 1, s.input[s.pos])
+	s.current.assign(sqliTokenTypeOperator, s.pos, 1, s.input[s.pos:])
 	return s.pos + 1
 }
 
 func parseByte(s *sqliState) int {
-	s.current.assignByte(s.input[s.pos], s.pos, 1, s.input[s.pos])
+	s.current.assign(s.input[s.pos], s.pos, 1, s.input[s.pos:])
 	return s.pos + 1
 }
 
@@ -107,7 +107,7 @@ func parseHash(s *sqliState) int {
 		s.statsCommentHash++
 		return parseEolComment(s)
 	}
-	s.current.assignByte(sqliTokenTypeOperator, s.pos, 1, '#')
+	s.current.assign(sqliTokenTypeOperator, s.pos, 1, "#")
 	return s.pos + 1
 }
 
@@ -128,7 +128,7 @@ func parseDash(s *sqliState) int {
 		s.statsCommentDDX++
 		return parseEolComment(s)
 	default:
-		s.current.assignByte(sqliTokenTypeOperator, s.pos, 1, '-')
+		s.current.assign(sqliTokenTypeOperator, s.pos, 1, "-")
 		return s.pos + 1
 	}
 }
@@ -174,7 +174,7 @@ func parseBackSlash(s *sqliState) int {
 		s.current.assign(sqliTokenTypeNumber, s.pos, 2, s.input[s.pos:])
 		return s.pos + 2
 	}
-	s.current.assignByte(sqliTokenTypeBackslash, s.pos, 1, s.input[s.pos])
+	s.current.assign(sqliTokenTypeBackslash, s.pos, 1, s.input[s.pos:])
 	return s.pos + 1
 }
 
@@ -321,7 +321,7 @@ func parseNumber(s *sqliState) int {
 
 		if pos-start == 1 {
 			// only one character read so far
-			s.current.assignByte(sqliTokenTypeDot, start, 1, '.')
+			s.current.assign(sqliTokenTypeDot, start, 1, ".")
 			return pos
 		}
 	}

--- a/sqli_parse.go
+++ b/sqli_parse.go
@@ -189,7 +189,7 @@ func parseOperator2(s *sqliState) int {
 		return s.pos + 3
 	}
 
-	ch := s.lookupWord(sqliLookupOperator, []byte(s.input[s.pos:s.pos+2]))
+	ch := s.lookupWord(sqliLookupOperator, s.input[s.pos:s.pos+2])
 	if ch != byteNull {
 		s.current.assign(ch, s.pos, 2, s.input[s.pos:])
 		return s.pos + 2

--- a/sqli_test.go
+++ b/sqli_test.go
@@ -195,6 +195,7 @@ func BenchmarkSQLiDriver(b *testing.B) {
 	}
 
 	b.Run("sqli", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			for _, tc := range cases.sqli {
 				tt := tc
@@ -204,6 +205,7 @@ func BenchmarkSQLiDriver(b *testing.B) {
 	})
 
 	b.Run("folding", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			for _, tc := range cases.folding {
 				tt := tc
@@ -213,6 +215,7 @@ func BenchmarkSQLiDriver(b *testing.B) {
 	})
 
 	b.Run("tokens", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			for _, tc := range cases.tokens {
 				tt := tc

--- a/sqli_token.go
+++ b/sqli_token.go
@@ -89,11 +89,7 @@ func (t *sqliToken) assignByte(tokenType byte, pos, _ int, value byte) {
 	t.category = tokenType
 	t.pos = pos
 	t.len = 1
-	if len(t.val) > 0 {
-		t.val = string(value) + t.val[1:]
-	} else {
-		t.val = string(value)
-	}
+	t.val = string(value)
 }
 
 func (t *sqliToken) isUnaryOp() bool {
@@ -107,7 +103,7 @@ func (t *sqliToken) isUnaryOp() bool {
 	case 2:
 		return t.val[0] == '!' && t.val[1] == '!'
 	case 3:
-		return toUpperCmp("NOT", string(t.val[:3]))
+		return toUpperCmp("NOT", t.val[:3])
 	default:
 		return false
 	}

--- a/sqli_token.go
+++ b/sqli_token.go
@@ -23,7 +23,7 @@ const (
 
 // Look forward for doubling of delimiter
 //
-// case 'foo”bar' -> foo”bar
+// case 'foo''bar' -> foo''bar
 //
 // ending quote is not duplicated (i.e. escaped)
 // since it's the wrong or EOL

--- a/sqli_token.go
+++ b/sqli_token.go
@@ -13,7 +13,7 @@ type sqliToken struct {
 	category byte
 	strOpen  byte
 	strClose byte
-	val      [32]byte
+	val      string
 }
 
 const (
@@ -23,7 +23,7 @@ const (
 
 // Look forward for doubling of delimiter
 //
-// case 'foo''bar' -> foo''bar
+// case 'foo”bar' -> foo”bar
 //
 // ending quote is not duplicated (i.e. escaped)
 // since it's the wrong or EOL
@@ -82,16 +82,18 @@ func (t *sqliToken) assign(tokenType byte, pos, length int, value string) {
 	t.category = tokenType
 	t.pos = pos
 	t.len = last
-	for i := 0; i < last; i++ {
-		t.val[i] = value[i]
-	}
+	t.val = value[:last]
 }
 
-func (t *sqliToken) assignByte(tokenType byte, pos, len int, value byte) {
+func (t *sqliToken) assignByte(tokenType byte, pos, _ int, value byte) {
 	t.category = tokenType
 	t.pos = pos
 	t.len = 1
-	t.val[0] = value
+	if len(t.val) > 0 {
+		t.val = string(value) + t.val[1:]
+	} else {
+		t.val = string(value)
+	}
 }
 
 func (t *sqliToken) isUnaryOp() bool {

--- a/sqli_token.go
+++ b/sqli_token.go
@@ -85,13 +85,6 @@ func (t *sqliToken) assign(tokenType byte, pos, length int, value string) {
 	t.val = value[:last]
 }
 
-func (t *sqliToken) assignByte(tokenType byte, pos, _ int, value byte) {
-	t.category = tokenType
-	t.pos = pos
-	t.len = 1
-	t.val = string(value)
-}
-
 func (t *sqliToken) isUnaryOp() bool {
 	if t.category != sqliTokenTypeOperator {
 		return false


### PR DESCRIPTION
- `string` for current token avoids copying, it is always just a slice into the input
- Most logic use string operations so using a string for both reduces intermediate conversions to string

After
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/libinjection-go
BenchmarkSQLiDriver
BenchmarkSQLiDriver/sqli
BenchmarkSQLiDriver/sqli-10         	   32025	     35962 ns/op	   49568 B/op	     297 allocs/op
BenchmarkSQLiDriver/folding
BenchmarkSQLiDriver/folding-10      	   12946	     93955 ns/op	   69889 B/op	    1718 allocs/op
BenchmarkSQLiDriver/tokens
BenchmarkSQLiDriver/tokens-10       	    6902	    165803 ns/op	  149562 B/op	    3689 allocs/op
PASS
```

Before
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/libinjection-go
BenchmarkSQLiDriver
BenchmarkSQLiDriver/sqli
BenchmarkSQLiDriver/sqli-10         	   29260	     40245 ns/op	   65665 B/op	     320 allocs/op
BenchmarkSQLiDriver/folding
BenchmarkSQLiDriver/folding-10      	   12258	     98190 ns/op	   89521 B/op	    1841 allocs/op
BenchmarkSQLiDriver/tokens
BenchmarkSQLiDriver/tokens-10       	    6506	    179106 ns/op	  191738 B/op	    4136 allocs/op
PASS
```