### PR TITLE
Replace ContainsRune with IndexByte

### DIFF
--- a/sqli.go
+++ b/sqli.go
@@ -381,7 +381,7 @@ func (s *sqliState) fold() int {
 		case s.tokenVec[left].category == sqliTokenTypeCollate && s.tokenVec[left+1].category == sqliTokenTypeBareWord:
 			// there are too many collation types.. so if the bareword has a "_"
 			// then it's TYPE_SQLTYPE
-			if strings.ContainsRune(s.tokenVec[left+1].val[:], '_') {
+			if strings.IndexByte(s.tokenVec[left+1].val[:], '_') != -1 {
 				s.tokenVec[left+1].category = sqliTokenTypeSQLType
 				left = 0
 			}
@@ -864,7 +864,7 @@ func (s *sqliState) check() bool {
 	// if input has a single quote, then
 	// test as if input was actually '
 	// example: if input if "1' = 1", then pretend it's "'1' = 1"
-	if strings.ContainsRune(s.input, rune(byteSingle)) {
+	if strings.IndexByte(s.input, byteSingle) != -1 {
 		s.sqliFingerprint(sqliFlagQuoteSingle | sqliFlagSQLAnsi)
 		if s.lookupWord(sqliLookupFingerprint, s.fingerprint) != byteNull {
 			return true
@@ -877,7 +877,7 @@ func (s *sqliState) check() bool {
 	}
 
 	// same as above but with a double quote
-	if strings.ContainsRune(s.input, rune(byteDouble)) {
+	if strings.IndexByte(s.input, byteDouble) != -1 {
 		s.sqliFingerprint(sqliFlagQuoteDouble | sqliFlagSQLMysql)
 		if s.lookupWord(sqliLookupFingerprint, s.fingerprint) != byteNull {
 			return true

--- a/sqli_helpers.go
+++ b/sqli_helpers.go
@@ -20,7 +20,7 @@ func flag2Delimiter(flag int) byte {
 //		   "   \\"	" two backslash = not escaped!
 //	    "  \\\"	" three backslash = escaped!
 func isBackslashEscaped(str string) bool {
-	if !strings.ContainsRune(str, '\\') {
+	if strings.IndexByte(str, '\\') == -1 {
 		return false
 	}
 
@@ -58,7 +58,7 @@ func isByteWhite(ch byte) bool {
 // regexp.match(str, "[ABC]*")
 func strLenSpn(s string, length int, accept string) int {
 	for i := 0; i < length; i++ {
-		if !strings.ContainsRune(accept, rune(s[i])) {
+		if strings.IndexByte(accept, s[i]) == -1 {
 			return i
 		}
 	}


### PR DESCRIPTION
After
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/libinjection-go
BenchmarkSQLiDriver
BenchmarkSQLiDriver/sqli
BenchmarkSQLiDriver/sqli-10         	   32134	     36256 ns/op	   49584 B/op	     321 allocs/op
BenchmarkSQLiDriver/folding
BenchmarkSQLiDriver/folding-10      	   12814	     93604 ns/op	   70664 B/op	    1775 allocs/op
BenchmarkSQLiDriver/tokens
BenchmarkSQLiDriver/tokens-10       	    7065	    165434 ns/op	  149562 B/op	    3689 allocs/op
PASS
```

Before
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/libinjection-go
BenchmarkSQLiDriver
BenchmarkSQLiDriver/sqli
BenchmarkSQLiDriver/sqli-10         	   26838	     38006 ns/op	   49584 B/op	     321 allocs/op
BenchmarkSQLiDriver/folding
BenchmarkSQLiDriver/folding-10      	   12643	     94539 ns/op	   70664 B/op	    1775 allocs/op
BenchmarkSQLiDriver/tokens
BenchmarkSQLiDriver/tokens-10       	    7063	    167293 ns/op	  149562 B/op	    3689 allocs/op
PASS
```