### PR TITLE
fix: inline tag closing check when reading attribute name to prevent deep recursion

### DIFF
--- a/xss_stack_overflow_test.go
+++ b/xss_stack_overflow_test.go
@@ -1,0 +1,16 @@
+package libinjection
+
+import (
+	"testing"
+)
+
+func TestMemory(t *testing.T) {
+	size := 10_000_000
+	input := make([]byte, size)
+	for i := range input {
+		input[i] = '/'
+	}
+
+	// should not overflow the stack
+	IsXSS(string(input))
+}


### PR DESCRIPTION
There is a recursion loop between stateSelfClosingStartTag and stateSelfClosingStartTag which in the worst case consumes 2 stack frames per input character.

We avoid this recursion by manual implementing tail call optimization (TCO) which a go compiler does not do automatically.

Also add a unit test to reproduce the problem in the first place.

This fixes #16