### PR TITLE
fix: use HasPrefix instead of Contains in htmlEncodeStartsWith

### DIFF
--- a/xss_helpers.go
+++ b/xss_helpers.go
@@ -169,7 +169,7 @@ func htmlEncodeStartsWith(a, b string) bool {
 		bs = append(bs, byte(cb&0xFF))
 	}
 
-	return strings.Contains(string(bs), a)
+	return strings.HasPrefix(string(bs), a)
 }
 
 func isBlackURL(s string) bool {

--- a/xss_helpers_test.go
+++ b/xss_helpers_test.go
@@ -45,3 +45,49 @@ func TestIsBlackAttr(t *testing.T) {
 		})
 	}
 }
+
+func TestHtmlEncodeStartsWith(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		input  string
+		want   bool
+	}{
+		{name: "exact match", prefix: "DATA", input: "data:", want: true},
+		{name: "prefix match with trailing content", prefix: "JAVA", input: "javascript:alert(1)", want: true},
+		{name: "no match", prefix: "DATA", input: "https://example.com", want: false},
+		{name: "pattern in middle should not match", prefix: "DATA", input: "https://github.com/Simbiat/database", want: false},
+		{name: "pattern at end should not match", prefix: "DATA", input: "nodata", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := htmlEncodeStartsWith(tt.prefix, tt.input); got != tt.want {
+				t.Errorf("htmlEncodeStartsWith(%q, %q) = %v, want %v", tt.prefix, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBlackURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "data URL", url: "data:text/html,<script>alert(1)</script>", want: true},
+		{name: "javascript URL", url: "javascript:alert(1)", want: true},
+		{name: "vbscript URL", url: "vbscript:msgbox", want: true},
+		{name: "https URL", url: "https://example.com", want: false},
+		{name: "URL containing data in path", url: "https://github.com/Simbiat/database", want: false},
+		{name: "URL containing java in path", url: "https://example.com/javascript-tutorials", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBlackURL(tt.url); got != tt.want {
+				t.Errorf("isBlackURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/xss_test.go
+++ b/xss_test.go
@@ -50,6 +50,9 @@ func TestIsXSS(t *testing.T) {
 		// True negatives
 		{input: "myvar=onfoobar==", isXSS: false},
 		{input: "onY29va2llcw==", isXSS: false}, // base64 encoded "thisisacookie", prefixed by "on"
+		// False positives from issue #46 - URLs containing black scheme names in path
+		{input: `=<a href="https://data">`, isXSS: false},
+		{input: `<a href="https://github.com/Simbiat/database">`, isXSS: false},
 	}
 
 	for _, example := range examples {


### PR DESCRIPTION
## what
- Changed `strings.Contains` to `strings.HasPrefix` in `htmlEncodeStartsWith` (`xss_helpers.go`)
- Added unit tests for `htmlEncodeStartsWith` and `isBlackURL`
- Added integration tests for the false positive payloads from issue #46

## why
The Go port of `htmlEncodeStartsWith` used `strings.Contains`, which matched blacklisted URL schemes (e.g. `DATA`) anywhere in the decoded string — not just at the start. This caused `isBlackURL` to flag legitimate URLs like `https://github.com/Simbiat/database` as XSS because `database` contains `data`. The C original does a character-by-character prefix match; `strings.HasPrefix` is the correct equivalent.

## refs
- Fixes #46
- Upstream CRS investigation: https://github.com/coreruleset/coreruleset/issues/3962