### PR TITLE
fix: correct SVG tag detection typo and use prefix matching in isBlackTag

### DIFF
--- a/xss_helpers.go
+++ b/xss_helpers.go
@@ -20,13 +20,13 @@ func isBlackTag(s string) bool {
 		}
 	}
 
-	switch sUpperWithoutNulls {
-	// anything SVG or XSL(t) related
-	case "SVT", "XSL":
+	// anything SVG or XSL(t) related (prefix match on first 3 chars)
+	if strings.HasPrefix(sUpperWithoutNulls, "SVG") ||
+		strings.HasPrefix(sUpperWithoutNulls, "XSL") {
 		return true
-	default:
-		return false
 	}
+
+	return false
 }
 
 func isBlackAttr(s string) int {

--- a/xss_helpers_test.go
+++ b/xss_helpers_test.go
@@ -91,3 +91,30 @@ func TestIsBlackURL(t *testing.T) {
 		})
 	}
 }
+
+func TestIsBlackTag(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want bool
+	}{
+		{name: "script tag", tag: "SCRIPT", want: true},
+		{name: "svg exact", tag: "svg", want: true},
+		{name: "SVG uppercase", tag: "SVG", want: true},
+		{name: "svg prefixed tag", tag: "svganimate", want: true},
+		{name: "svg namespaced", tag: "svg:rect", want: true},
+		{name: "xsl exact", tag: "xsl", want: true},
+		{name: "xsl prefixed tag", tag: "xsl:template", want: true},
+		{name: "div tag", tag: "div", want: false},
+		{name: "span tag", tag: "span", want: false},
+		{name: "too short", tag: "sv", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBlackTag(tt.tag); got != tt.want {
+				t.Errorf("isBlackTag(%q) = %v, want %v", tt.tag, got, tt.want)
+			}
+		})
+	}
+}

--- a/xss_test.go
+++ b/xss_test.go
@@ -52,6 +52,10 @@ func TestIsXSS(t *testing.T) {
 		{input: "<!--xmlfoo-->", isXSS: true},
 		{input: "<!--xml:namespace-->", isXSS: true},
 		{input: "<!--XML -->", isXSS: true},
+		// SVG tags
+		{input: "<svg>", isXSS: true},
+		{input: "<svg onload=alert(1)>", isXSS: true},
+		{input: "<svganimate>", isXSS: true},
 		// True negatives
 		{input: "<!--xml-->", isXSS: false},  // tokenLen=3, doesn't reach XML check
 		{input: "<!--?xml -->", isXSS: false}, // "xml" not at start of token
@@ -117,7 +121,7 @@ func runXSSTest(t testing.TB, data map[string]string, filename, flag string) {
 
 	switch flag {
 	case xss:
-		if IsXSS(data["--INPUT--"]) {
+		if IsXSS(data[sectionInput]) {
 			actual = "1"
 		} else {
 			actual = "0"


### PR DESCRIPTION
## what
- fixed "SVT" typo to "SVG" in `isBlackTag` (`xss_helpers.go`)
- changed exact string matching to prefix matching via `strings.HasPrefix` for both SVG and XSL patterns
- added unit tests for `isBlackTag` and integration tests for SVG tag detection

## why
The C original checks only the first 3 characters of the tag name, so `<svganimate>`, `<svg:rect>`, `<xsl:template>` etc. are all considered dangerous. The Go port had a typo ("SVT" instead of "SVG") and used exact matching, meaning no SVG tags were detected at all and XSL sub-tags like `<xsl:template>` were missed.

## refs
- [C implementation](https://github.com/libinjection/libinjection/blob/main/src/libinjection_xss.c#L969-L981): `libinjection_xss.c:969-981`