### PR TITLE
fix: correct off-by-one in XML comment detection in XSS checker

### DIFF
--- a/xss.go
+++ b/xss.go
@@ -63,7 +63,7 @@ func isXSS(input string, flags int) bool {
 					return true
 				}
 
-				if strings.ToUpper(h5.tokenStart[1:4]) == "XML" {
+				if strings.ToUpper(h5.tokenStart[0:3]) == "XML" {
 					return true
 				}
 			}

--- a/xss_test.go
+++ b/xss_test.go
@@ -47,7 +47,15 @@ func TestIsXSS(t *testing.T) {
 		{input: "<img onpageswap=alert(1)>", isXSS: true},
 		{input: "<img onscrollsnapchange=alert(1)>", isXSS: true},
 		{input: "<img onscrollsnapchanging=alert(1)>", isXSS: true},
+		// XML comment detection (tokenLen must be > 3 to reach this check)
+		{input: "<!--xml -->", isXSS: true},
+		{input: "<!--xmlfoo-->", isXSS: true},
+		{input: "<!--xml:namespace-->", isXSS: true},
+		{input: "<!--XML -->", isXSS: true},
 		// True negatives
+		{input: "<!--xml-->", isXSS: false},  // tokenLen=3, doesn't reach XML check
+		{input: "<!--?xml -->", isXSS: false}, // "xml" not at start of token
+		{input: "<!--axml -->", isXSS: false}, // "xml" not at start of token
 		{input: "myvar=onfoobar==", isXSS: false},
 		{input: "onY29va2llcw==", isXSS: false}, // base64 encoded "thisisacookie", prefixed by "on"
 	}


### PR DESCRIPTION
## what
- fixed `tokenStart[1:4]` to `tokenStart[0:3]` in XML comment detection (`xss.go:66`)
- added tests for true positives: `<!--xml -->`, `<!--xmlfoo-->`, `<!--xml:namespace-->`, `<!--XML -->`
- added tests for true negatives: `<!--?xml -->`, `<!--axml -->` (previously false positives)

## why
The C original checks `token_start[0]`, `[1]`, `[2]` for "XML" in HTML comment tokens. The Go port was off by one, checking positions 1-3 instead of 0-2. This caused false negatives for comments starting with "xml" and false positives for comments where "xml" happened to appear at position 1.

## refs
- C implementation: `libinjection_xss.c:1147-1150`