### PR TITLE
fix: implement XSS test driver for test-xss-* files

### DIFF
--- a/tests/test-xss-001.txt
+++ b/tests/test-xss-001.txt
@@ -1,0 +1,6 @@
+--TEST--
+XSS via script tag
+--INPUT--
+<script>alert(1);</script>
+--EXPECTED--
+1

--- a/tests/test-xss-002.txt
+++ b/tests/test-xss-002.txt
@@ -1,0 +1,6 @@
+--TEST--
+XSS via javascript URL in href
+--INPUT--
+<a href="javascript:alert(1)">
+--EXPECTED--
+1

--- a/tests/test-xss-003.txt
+++ b/tests/test-xss-003.txt
@@ -1,0 +1,6 @@
+--TEST--
+XSS via event handler
+--INPUT--
+<img onerror=alert(1)>
+--EXPECTED--
+1

--- a/tests/test-xss-004.txt
+++ b/tests/test-xss-004.txt
@@ -1,0 +1,6 @@
+--TEST--
+Not XSS, benign HTML
+--INPUT--
+<a href="https://example.com">link</a>
+--EXPECTED--
+0

--- a/tests/test-xss-005.txt
+++ b/tests/test-xss-005.txt
@@ -1,0 +1,6 @@
+--TEST--
+Not XSS, plain text
+--INPUT--
+hello world
+--EXPECTED--
+0

--- a/tests/test-xss-006.txt
+++ b/tests/test-xss-006.txt
@@ -1,0 +1,6 @@
+--TEST--
+XSS via data URL in href
+--INPUT--
+<a href="data:text/html,<script>alert(1)</script>">
+--EXPECTED--
+1

--- a/tests/test-xss-007.txt
+++ b/tests/test-xss-007.txt
@@ -1,0 +1,6 @@
+--TEST--
+XSS via DOCTYPE
+--INPUT--
+<!DOCTYPE html>
+--EXPECTED--
+1

--- a/xss_test.go
+++ b/xss_test.go
@@ -106,7 +106,11 @@ func runXSSTest(t testing.TB, data map[string]string, filename, flag string) {
 
 	switch flag {
 	case xss:
-
+		if IsXSS(data["--INPUT--"]) {
+			actual = "1"
+		} else {
+			actual = "0"
+		}
 	case html5:
 		h5 := new(h5State)
 		h5.init(data["--INPUT--"], html5FlagsDataState)
@@ -133,9 +137,14 @@ func TestXSSDriver(t *testing.T) {
 	for _, fi := range dir {
 		p := filepath.Join(baseDir, fi.Name())
 		data := readTestData(p)
-		if strings.Contains(fi.Name(), "-html5-") {
+		switch {
+		case strings.Contains(fi.Name(), "-html5-"):
 			t.Run(fi.Name(), func(t *testing.T) {
 				runXSSTest(t, data, p, html5)
+			})
+		case strings.Contains(fi.Name(), "-xss-"):
+			t.Run(fi.Name(), func(t *testing.T) {
+				runXSSTest(t, data, p, xss)
 			})
 		}
 	}
@@ -155,6 +164,7 @@ func BenchmarkXSSDriver(b *testing.B) {
 
 	cases := struct {
 		html5 []testCaseXSS
+		xss   []testCaseXSS
 	}{}
 
 	for _, fi := range dir {
@@ -167,7 +177,8 @@ func BenchmarkXSSDriver(b *testing.B) {
 		switch {
 		case strings.Contains(fi.Name(), "-html5-"):
 			cases.html5 = append(cases.html5, tc)
-		default:
+		case strings.Contains(fi.Name(), "-xss-"):
+			cases.xss = append(cases.xss, tc)
 		}
 	}
 
@@ -177,6 +188,16 @@ func BenchmarkXSSDriver(b *testing.B) {
 			for _, tc := range cases.html5 {
 				tt := tc
 				runXSSTest(b, tt.data, tt.name, html5)
+			}
+		}
+	})
+
+	b.Run("xss", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			for _, tc := range cases.xss {
+				tt := tc
+				runXSSTest(b, tt.data, tt.name, xss)
 			}
 		}
 	})


### PR DESCRIPTION
## what
- implemented the `case xss:` branch in `runXSSTest` to call `IsXSS` and compare against expected `"1"`/`"0"` values
- added `test-xss-*` file dispatch in `TestXSSDriver` and `BenchmarkXSSDriver`
- added 7 initial `test-xss-*` test files (script tag, javascript URL, event handler, data URL, DOCTYPE, and benign inputs)

## why
The C test driver (`testdriver.c`) supports `test-xss-*` files as testtype 4, running `libinjection_xss()` and comparing the numeric result. The Go test framework had the `case xss:` branch as a no-op, silently skipping any XSS detection test files. This makes the Go test framework match the C driver's capabilities.

## refs
- C test driver: `testdriver.c:241-245` (testtype 4) and `testdriver.c:302-304` (file dispatch)