### PR TITLE
fix: align test file parser with C testdriver behavior

### DIFF
--- a/xss_test.go
+++ b/xss_test.go
@@ -109,7 +109,7 @@ func runXSSTest(t testing.TB, data map[string]string, filename, flag string) {
 
 	case html5:
 		h5 := new(h5State)
-		h5.init(data["--INPUT--"], html5FlagsDataState)
+		h5.init(data[sectionInput], html5FlagsDataState)
 
 		for h5.next() {
 			actual += printHTML5Token(h5) + "\n"
@@ -117,9 +117,9 @@ func runXSSTest(t testing.TB, data map[string]string, filename, flag string) {
 	}
 
 	actual = strings.TrimSpace(actual)
-	if actual != data["--EXPECTED--"] {
+	if actual != data[sectionExpected] {
 		t.Errorf("FILE: (%s)\nINPUT: (%s)\nEXPECTED: (%s)\nGOT: (%s)\n",
-			filename, data["--INPUT--"], data["--EXPECTED--"], actual)
+			filename, data[sectionInput], data[sectionExpected], actual)
 	}
 }
 


### PR DESCRIPTION
## what
- stopped trimming each line with `TrimSpace` before appending; raw line content is now preserved
- added section ordering validation via count state machine (`--TEST--` → `--INPUT--` → `--EXPECTED--`), panicking on malformed test files
- switched final value trimming from `TrimSpace` to `TrimRight` to match C's `modp_rtrim` (right-trim only)
- changed `printToken` from `TrimSpace` to `TrimRight("\n\r")` to preserve trailing spaces in token output, matching C's `print_token`

## why
The Go test parser diverged from the C `testdriver.c:read_file` in two ways:
1. It called `bytes.TrimSpace` on every line before appending, which could strip intentional leading/trailing whitespace from test inputs and expected outputs.
2. It had no validation that all three required sections were present, silently producing empty values for malformed files.

The C driver preserves raw line content via `strcat`, enforces section order with a count variable, and only right-trims the final strings with `modp_rtrim`.

## refs
- C test driver: `testdriver.c:147-191`